### PR TITLE
fix: guard activity speed check on data changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/src/adapters/mongo/models/Activity.ts
+++ b/src/adapters/mongo/models/Activity.ts
@@ -78,15 +78,23 @@ ActivitySchema.pre('save', async function (next) {
     const user = await model('User').findById(this.userId);
     if (!user) return next(new Error('Invalid userId'));
   }
-  if (this.distanceM && this.durationS && this.isModified('distanceM') || this.isModified('durationS')) {
+  // Validate speed when distance or duration changes
+  if (
+    (this.isModified('distanceM') || this.isModified('durationS')) &&
+    this.distanceM > 0 &&
+    this.durationS > 0
+  ) {
     const speedKmh = (this.distanceM / 1000) / (this.durationS / 3600);
-    if (this.type === 'RUN' && speedKmh > 24) { // ~15 mph max for running
+    if (this.type === 'RUN' && speedKmh > 24) {
+      // ~15 mph max for running
       return next(new Error('Running speed exceeds realistic limits'));
     }
-    if (this.type === 'WALK' && speedKmh > 10) { // ~6 mph max for walking
+    if (this.type === 'WALK' && speedKmh > 10) {
+      // ~6 mph max for walking
       return next(new Error('Walking speed exceeds realistic limits'));
     }
-    if (this.type === 'RIDE' && speedKmh > 60) { // ~37 mph max for cycling
+    if (this.type === 'RIDE' && speedKmh > 60) {
+      // ~37 mph max for cycling
       return next(new Error('Cycling speed exceeds realistic limits'));
     }
   }


### PR DESCRIPTION
## Summary
- ensure activity speed validation only runs when distance or duration changes and values are positive
- add `npm test` script for TypeScript type checks

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9cc72d748330b11f8e0997819c44